### PR TITLE
Improvements to let the user choose any container name

### DIFF
--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -10,6 +10,12 @@ echo "> Building the cluster"
 echo -e ${NOCOLOR}
 bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config /root/kind.yml'
 
+# Retrieve docker container id
+# Docker >= 1.12 - $HOSTNAME seems to be the short container id
+if ! docker ps | grep -q $HOSTNAME; then
+    echo "[ERROR] - Unable to retrieve the container id."
+    exit 1
+fi
 # Connect the director node on the same net
 # TO-DO: Change whaley with the container name
 docker network connect kind whaley

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -16,9 +16,9 @@ if ! docker ps | grep -q $HOSTNAME; then
     echo "[ERROR] - Unable to retrieve the container id."
     exit 1
 fi
-# Connect the director node on the same net
-# TO-DO: Change whaley with the container name
-docker network connect kind whaley
+
+# Connect the  jump host node on the same net
+docker network connect kind $HOSTNAME
 
 echo -e ${GREEN}
 echo "> Modifying Kubernetes config to point to the master node"
@@ -51,7 +51,7 @@ echo "> Setting up the dashboard proxy"
 echo -e ${NOCOLOR}
 # 'whaley' in the next line is the main container name
 # TO-DO: Change whaley with the container name
-CLIENT_IP=$(docker inspect --format='{{.NetworkSettings.Networks.kind.IPAddress}}' whaley)
+CLIENT_IP=$(docker inspect --format='{{.NetworkSettings.Networks.kind.IPAddress}}' $HOSTNAME)
 kubectl proxy --address=$CLIENT_IP --accept-hosts=^localhost$,^127\.0\.0\.1$,^\[::1\]$ &
 echo "You can access the dashboard from there: http://127.0.0.1:30303/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/"
 


### PR DESCRIPTION
This will let the user choose any container name (also random) automatically retrieving the jump-host server container id through the `$HOSTNAME` docker variable.