### PR TITLE
Add a script flag to let the user define the worker counts

### DIFF
--- a/kind.yml
+++ b/kind.yml
@@ -8,5 +8,5 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: whaley
 nodes:
 - role: control-plane
-- role: worker
-- role: worker
+#- role: worker
+#- role: worker

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+WORKERS=3
+
+# Parse options from the CLI
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
+  -w | --workers )
+    shift; WORKERS=$1
+    ;;
+esac; shift; done
+if [[ "$1" == '--' ]]; then shift; fi
+
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -4,11 +4,13 @@ WORKERS=3
 
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
-  -w | --workers )
-    shift; WORKERS=$1
-    ;;
+    -w | --workers )
+        shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=3
+        ;;
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
+
+echo "> Workers count is: $WORKERS"
 
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -10,8 +10,6 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
-echo "> Workers count is: $WORKERS"
-
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-WORKERS=3
+WORKERS=2
 
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -w | --workers )
-        shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=3
+        shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=2
         ;;
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -10,6 +10,10 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
+for (( i = 0 ; i < $WORKERS; i++)); do
+    echo "- role: worker" >> /root/kind.yml
+done
+
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?


### PR DESCRIPTION
Introduce `--workers` flag to let the user define the worker counts. Based on that value, the script will add several `- role: worker` lines in the kind configuration file.

It includes also a value check, and if the user input is not numerical then the default value (`2`) is used.