### PR TITLE
Create control plane nodes based on user input

### DIFF
--- a/kind.yml
+++ b/kind.yml
@@ -7,6 +7,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: whaley
 nodes:
-- role: control-plane
+#- role: control-plane
 #- role: worker
 #- role: worker

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+MASTERS=1
 WORKERS=2
 
 # Parse options from the CLI
@@ -7,9 +8,16 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -w | --workers )
         shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=2
         ;;
+    -m | --masters)
+        shift; [[ "$1" =~ ^[0-9]$ ]] && MASTERS=$1 || MASTERS=1
+        ;;
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
+# Populate kind config file with both control-plane and workers nodes
+for (( i = 0 ; i < $MASTERS; i++)); do
+    echo "- role: control-plane" >> /root/kind.yml
+done
 for (( i = 0 ; i < $WORKERS; i++)); do
     echo "- role: worker" >> /root/kind.yml
 done


### PR DESCRIPTION
This PR introduce the flag `--masters` to let the user define the number of control-plane nodes. Based on that value, the script will add several `- role: control-plane` in `kind.yml`.

Also in this case we have a value check, if the value passed is wrong then the default value (`1`) will be used.