### PR TITLE
Ship `whaley 1.2.1` 📦

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2023/08/07
+
 ### Added
 
 - Let the user define control-plane nodes using `--masters` option. By default, one control-plane will be created.
@@ -26,3 +28,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 I'm sorry, I wasn't planning any release for the project, that's why I started writing down the following file only after those versions were created 😞.
 
 [unreleased]: https://github.com/imgios/whaley/compare/main...dev
+[1.2.1]: https://github.com/imgios/whaley/releases/tag/1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Let the user define worker nodes using `-w|--workers` options. By default, two worker nodes will be created.
 - Let the user define the cluster name using `--name` option. By default, its name is `whaley`.
 
+### Changed
+
+- whaley workdir changed from `/root/` to `/.whaley/`
+
 ## From 1.0 to 1.2 - 2023/03
 
 I'm sorry, I wasn't planning any release for the project, that's why I started writing down the following file only after those versions were created 😞.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - whaley workdir changed from `/root/` to `/.whaley/`
 
+### Removed
+
+- The cluster won't be deleted anymore when closing (`exit`) the bash on the jumphost.
+
 ## From 1.0 to 1.2 - 2023/03
 
 I'm sorry, I wasn't planning any release for the project, that's why I started writing down the following file only after those versions were created 😞.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Let the user define control-plane nodes using `--masters` options. By default, one control-plane will be created.
+- Let the user define worker nodes using `-w|--workers` options. By defaultt, two worker nodes will be created.
+
+## From 1.0 to 1.2 - 2023/03
+
+I'm sorry, I wasn't planning any release for the project, that's why I started writing down the following file only after those versions were created 😞.
+
+[unreleased]: https://github.com/imgios/whaley/compare/main...dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Let the user define control-plane nodes using `--masters` options. By default, one control-plane will be created.
-- Let the user define worker nodes using `-w|--workers` options. By defaultt, two worker nodes will be created.
+- Let the user define worker nodes using `-w|--workers` options. By default, two worker nodes will be created.
 
 ## From 1.0 to 1.2 - 2023/03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Let the user define control-plane nodes using `--masters` options. By default, one control-plane will be created.
+- Let the user define control-plane nodes using `--masters` option. By default, one control-plane will be created.
 - Let the user define worker nodes using `-w|--workers` options. By default, two worker nodes will be created.
+- Let the user define the cluster name using `--name` option. By default, its name is `whaley`.
 
 ## From 1.0 to 1.2 - 2023/03
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     git \
     jq \
     openssl \
+    sed \
     shadow \
     vim \
     wget

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,10 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
     chmod 700 get_helm.sh && \
     ./get_helm.sh
 
-ADD scripts /root/scripts
+ADD scripts /.whaley/scripts
 
-COPY kind.yml /root/
+COPY kind.yml /.whaley/
 
-ENV PATH="${PATH}:/root"
+ENV PATH="${PATH}:/.whaley"
 
-ENTRYPOINT ["/bin/bash", "/root/scripts/cluster-init.sh"]
+ENTRYPOINT ["/bin/bash", "/.whaley/scripts/cluster-init.sh"]

--- a/kind.yml
+++ b/kind.yml
@@ -8,5 +8,5 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: whaley
 nodes:
 - role: control-plane
-- role: worker
-- role: worker
+#- role: worker
+#- role: worker

--- a/kind.yml
+++ b/kind.yml
@@ -7,6 +7,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: whaley
 nodes:
-- role: control-plane
+#- role: control-plane
 #- role: worker
 #- role: worker

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -84,10 +84,7 @@ echo "You can access the dashboard from there: http://127.0.0.1:30303/api/v1/nam
 
 # Start up a bash shell to try out Kubernetes
 cd
+echo
+echo -e "\U2139 Execute the following command if you want to destroy the cluster:"
+echo "      kind delete cluster --name ${NAME}"
 /bin/bash
-
-# Delete the cluster at the end
-echo -e ${GREEN}
-echo "> Deleting the cluster"
-echo -e ${NOCOLOR}
-kind delete cluster --name ${NAME}

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+WORKERS=3
+
+# Parse options from the CLI
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
+  -w | --workers )
+    shift; WORKERS=$1
+    ;;
+esac; shift; done
+if [[ "$1" == '--' ]]; then shift; fi
+
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+MASTERS=1
 WORKERS=2
 
 # Parse options from the CLI
@@ -7,9 +8,16 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -w | --workers )
         shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=2
         ;;
+    -m | --masters)
+        shift; [[ "$1" =~ ^[0-9]$ ]] && MASTERS=$1 || MASTERS=1
+        ;;
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
+# Populate kind config file with both control-plane and workers nodes
+for (( i = 0 ; i < $MASTERS; i++)); do
+    echo "- role: control-plane" >> /root/kind.yml
+done
 for (( i = 0 ; i < $WORKERS; i++)); do
     echo "- role: worker" >> /root/kind.yml
 done

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -4,11 +4,13 @@ WORKERS=3
 
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
-  -w | --workers )
-    shift; WORKERS=$1
-    ;;
+    -w | --workers )
+        shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=3
+        ;;
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
+
+echo "> Workers count is: $WORKERS"
 
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -11,6 +11,11 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -m | --masters)
         shift; [[ "$1" =~ ^[0-9]$ ]] && MASTERS=$1 || MASTERS=1
         ;;
+    --name)
+        if [[ -n "$2" && ! "$2" =~ ^- && ! "$1" == "--" ]]; then
+            shift
+            sed -i "s/whaley/$1/g" /root/kind.yml
+        fi
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -14,17 +14,17 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     --name)
         if [[ -n "$2" && ! "$2" =~ ^- && ! "$1" == "--" ]]; then
             shift; NAME=$1
-            sed -i "s/whaley/$NAME/g" /root/kind.yml
+            sed -i "s/whaley/$NAME/g" /.whaley/kind.yml
         fi
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
 # Populate kind config file with both control-plane and workers nodes
 for (( i = 0 ; i < $MASTERS; i++)); do
-    echo "- role: control-plane" >> /root/kind.yml
+    echo "- role: control-plane" >> /.whaley/kind.yml
 done
 for (( i = 0 ; i < $WORKERS; i++)); do
-    echo "- role: worker" >> /root/kind.yml
+    echo "- role: worker" >> /.whaley/kind.yml
 done
 
 GREEN='\033[0;32m'
@@ -35,7 +35,7 @@ export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME
 echo -e ${GREEN}
 echo "> Building the cluster"
 echo -e ${NOCOLOR}
-bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config /root/kind.yml'
+bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config /.whaley/kind.yml'
 
 # Retrieve docker container id
 # Docker >= 1.12 - $HOSTNAME seems to be the short container id

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -35,7 +35,7 @@ export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME
 echo -e ${GREEN}
 echo "> Building the cluster"
 echo -e ${NOCOLOR}
-bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config /.whaley/kind.yml'
+bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config /.whaley/kind.yml' || exit 1
 
 # Retrieve docker container id
 # Docker >= 1.12 - $HOSTNAME seems to be the short container id

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -10,8 +10,6 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
-echo "> Workers count is: $WORKERS"
-
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-WORKERS=3
+WORKERS=2
 
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -w | --workers )
-        shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=3
+        shift; [[ "$1" =~ ^[0-9]$ ]] && WORKERS=$1 || WORKERS=2
         ;;
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -10,6 +10,10 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
+for (( i = 0 ; i < $WORKERS; i++)); do
+    echo "- role: worker" >> /root/kind.yml
+done
+
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -2,7 +2,7 @@
 
 MASTERS=1
 WORKERS=2
-
+NAME=whaley
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -w | --workers )
@@ -13,8 +13,8 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
         ;;
     --name)
         if [[ -n "$2" && ! "$2" =~ ^- && ! "$1" == "--" ]]; then
-            shift
-            sed -i "s/whaley/$1/g" /root/kind.yml
+            shift; NAME=$1
+            sed -i "s/whaley/$NAME/g" /root/kind.yml
         fi
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
@@ -30,7 +30,7 @@ done
 GREEN='\033[0;32m'
 NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?
-export PS1="\[\e]0;\u@whaley: \w\a\]${debian_chroot:+($debian_chroot)}\u@whaley:\w\$ "
+export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
 echo -e ${GREEN}
 echo "> Building the cluster"
@@ -50,7 +50,7 @@ docker network connect kind $HOSTNAME
 echo -e ${GREEN}
 echo "> Modifying Kubernetes config to point to the master node"
 echo -e ${NOCOLOR}
-MASTER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' whaley-control-plane)
+MASTER_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${NAME}-control-plane)
 sed -i "s/^    server:.*/    server: https:\/\/$MASTER_IP:6443/" $HOME/.kube/config
 cd
 
@@ -90,4 +90,4 @@ cd
 echo -e ${GREEN}
 echo "> Deleting the cluster"
 echo -e ${NOCOLOR}
-kind delete cluster --name whaley
+kind delete cluster --name ${NAME}


### PR DESCRIPTION
### Added

- Let the user define control-plane nodes using `--masters` option. By default, one control-plane will be created.
- Let the user define worker nodes using `-w|--workers` options. By default, two worker nodes will be created.
- Let the user define the cluster name using `--name` option. By default, its name is `whaley`.

### Changed

- whaley workdir changed from `/root/` to `/.whaley/`

### Removed

- The cluster won't be deleted anymore when closing (`exit`) the bash on the jumphost.