### PR TITLE
Include opencontainers labels in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.17 as whaley
 LABEL org.opencontainers.image.authors="@imgios"
 LABEL org.opencontainers.image.source="https://github.com/imgios/whaley"
+LABEL org.opencontainers.image.description="Kubernetes-in-Docker (kind) project to run a small local Kubernetes cluster using Docker container nodes."
 
 RUN apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.17 as whaley
+LABEL org.opencontainers.image.authors="@imgios"
 
 RUN apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.17 as whaley
 LABEL org.opencontainers.image.authors="@imgios"
+LABEL org.opencontainers.image.source="https://github.com/imgios/whaley"
 
 RUN apk add --no-cache \
     bash \


### PR DESCRIPTION
The following PR introduces opencontainers labels in the Dockerfile, regarding:
- `authors :: org.opencontainers.image.authors`
- `source code :: org.opencontainers.image.source`
- `description :: org.opencontainers.image.description`

Linked to the issue #20 