### PR TITLE
Detect `kind.yml` mounted by the user

### DIFF
--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -35,7 +35,7 @@ NOCOLOR='\033[0m'
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
 # Check if kind.yml has been mounted in /.whaley/config/kind.yml
-if [[ -e "/.whaley/config/kind.yml "]]; then
+if [[ -e "/.whaley/config/kind.yml" ]]; then
     _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -40,7 +40,7 @@ if [[ -e "/.whaley/config/kind.yml" ]]; then
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config
 elif [[ -e "/.whaley/config/kind.yaml" ]]; then
-    _config=/.whaley/config/kind.yml
+    _config=/.whaley/config/kind.yaml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config
 fi

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -34,9 +34,9 @@ NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
-# Check if kind.yml has been mounted in /.whaley/user-config
-if [[ -e "/.whaley/user-config/kind.yml "]]; then
-    _config=/.whaley/user-config/kind.yml
+# Check if kind.yml has been mounted in /.whaley/config/kind.yml
+if [[ -e "/.whaley/config/kind.yml "]]; then
+    _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config
 fi

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -45,7 +45,7 @@ fi
 echo -e ${GREEN}
 echo "> Building the cluster"
 echo -e ${NOCOLOR}
-bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config ${_config}' || exit 1
+/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config ${_config} || exit 1
 
 # Retrieve docker container id
 # Docker >= 1.12 - $HOSTNAME seems to be the short container id

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -38,10 +38,12 @@ export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME
 if [[ -e "/.whaley/config/kind.yml" ]]; then
     _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    echo
     cat $_config
 elif [[ -e "/.whaley/config/kind.yaml" ]]; then
     _config=/.whaley/config/kind.yaml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    echo
     cat $_config
 fi
     

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -34,8 +34,12 @@ NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
-# Check if kind.yml has been mounted in /.whaley/config/kind.yml
+# Check if kind.yml (or .yaml) has been mounted in /.whaley/config/kind.yml (or .yaml)
 if [[ -e "/.whaley/config/kind.yml" ]]; then
+    _config=/.whaley/config/kind.yml
+    echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    cat $_config
+elif [[ -e "/.whaley/config/kind.yaml" ]]; then
     _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -3,7 +3,7 @@
 MASTERS=1
 WORKERS=2
 NAME=whaley
-_config=/.whaley/kind.yaml
+_config=/.whaley/kind.yml
 
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -3,6 +3,8 @@
 MASTERS=1
 WORKERS=2
 NAME=whaley
+_config=/.whaley/kind.yaml
+
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -w | --workers )
@@ -14,17 +16,17 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     --name)
         if [[ -n "$2" && ! "$2" =~ ^- && ! "$1" == "--" ]]; then
             shift; NAME=$1
-            sed -i "s/whaley/$NAME/g" /.whaley/kind.yml
+            sed -i "s/whaley/$NAME/g" $_config
         fi
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
 # Populate kind config file with both control-plane and workers nodes
 for (( i = 0 ; i < $MASTERS; i++)); do
-    echo "- role: control-plane" >> /.whaley/kind.yml
+    echo "- role: control-plane" >> $_config
 done
 for (( i = 0 ; i < $WORKERS; i++)); do
-    echo "- role: worker" >> /.whaley/kind.yml
+    echo "- role: worker" >> $_config
 done
 
 GREEN='\033[0;32m'
@@ -32,10 +34,18 @@ NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
+# Check if kind.yml has been mounted in /.whaley/user-config
+if [[ -e "/.whaley/user-config/kind.yml "]]; then
+    _config=/.whaley/user-config/kind.yml
+    echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    cat $_config
+fi
+    
+
 echo -e ${GREEN}
 echo "> Building the cluster"
 echo -e ${NOCOLOR}
-bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config /.whaley/kind.yml' || exit 1
+bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config ${_config}' || exit 1
 
 # Retrieve docker container id
 # Docker >= 1.12 - $HOSTNAME seems to be the short container id


### PR DESCRIPTION
This PR detects when a `kind.yml` config file is mounted in `/.whaley/config` and uses it to create the cluster, otherwise will keep using the default `kind.yml` available by default.

Example:
```shell
imgios@machine:~$ docker run --name k8s-local-dev --rm -p 30303:8001 -v /var/run/docker.sock:/var/run/docker.sock -v /home/imgios/kind.yml:/.whaley/config/kind.yml -it whaley:dev
INFO :: User cluster config file detected! The following configuration will be used:
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
name: whaley
nodes:
- role: control-plane
- role: worker
- role: worker

> Building the cluster

Creating cluster "whaley" ...
 ✓ Ensuring node image (kindest/node:v1.25.2) 🖼
 ✓ Preparing nodes 📦 📦 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
 ✓ Joining worker nodes 🚜
Set kubectl context to "kind-whaley"
You can now use your cluster with:

kubectl cluster-info --context kind-whaley

Have a nice day! 👋

> Modifying Kubernetes config to point to the master node

node/whaley-worker labeled
node/whaley-worker2 labeled

> Deploying the Kubernetes Dashboard

namespace/kubernetes-dashboard created
serviceaccount/kubernetes-dashboard created
service/kubernetes-dashboard created
secret/kubernetes-dashboard-certs created
secret/kubernetes-dashboard-csrf created
secret/kubernetes-dashboard-key-holder created
configmap/kubernetes-dashboard-settings created
role.rbac.authorization.k8s.io/kubernetes-dashboard created
clusterrole.rbac.authorization.k8s.io/kubernetes-dashboard created
rolebinding.rbac.authorization.k8s.io/kubernetes-dashboard created
clusterrolebinding.rbac.authorization.k8s.io/kubernetes-dashboard created
deployment.apps/kubernetes-dashboard created
service/dashboard-metrics-scraper created
deployment.apps/dashboard-metrics-scraper created

> Creating the RBAC to access the Dashboard

serviceaccount/k8s-dashboard-admin-sa created
clusterrolebinding.rbac.authorization.k8s.io/k8s-dashboard-admin-sa created

> Setting up the dashboard proxy

You can access the dashboard from there: http://127.0.0.1:30303/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/

ℹ Execute the following command if you want to destroy the cluster:
      kind delete cluster --name whaley
```