### PR TITLE
Release whaley `1.2.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@ I'm sorry, I wasn't planning any release for the project, that's why I started w
 
 [unreleased]: https://github.com/imgios/whaley/compare/main...dev
 [1.2.1]: https://github.com/imgios/whaley/releases/tag/1.2.1
+[1.2.2]: https://github.com/imgios/whaley/releases/tag/1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.2] - 2023/08/30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Detect custom cluster configuration file (they must be named `kind.yaml` or `kind.yml`) in `/.whaley/config` to customize `kind` cluster creation using an already made configuration file:
+
+```shell
+whaley@docker:~$ docker run --name k8s-local-dev --rm \
+-p 30303:8001 \
+-v /var/run/docker.sock:/var/run/docker.sock \
+-v /home/imgios/kind.yml:/.whaley/config/kind.yml \
+-it whaley:dev
+```
+
 - OpenContainers labels about the author, the source code and the image description.
 
 ## [1.2.1] - 2023/08/07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- OpenContainers labels about the author, the source code and the image description.
+
 ## [1.2.1] - 2023/08/07
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.17 as whaley
 LABEL org.opencontainers.image.authors="@imgios"
 LABEL org.opencontainers.image.source="https://github.com/imgios/whaley"
+LABEL org.opencontainers.image.description="Kubernetes-in-Docker (kind) project to run a small local Kubernetes cluster using Docker container nodes."
 
 RUN apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.17 as whaley
+LABEL org.opencontainers.image.authors="@imgios"
 
 RUN apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.17 as whaley
 LABEL org.opencontainers.image.authors="@imgios"
+LABEL org.opencontainers.image.source="https://github.com/imgios/whaley"
 
 RUN apk add --no-cache \
     bash \

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -35,7 +35,7 @@ NOCOLOR='\033[0m'
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
 # Check if kind.yml has been mounted in /.whaley/config/kind.yml
-if [[ -e "/.whaley/config/kind.yml "]]; then
+if [[ -e "/.whaley/config/kind.yml" ]]; then
     _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -40,7 +40,7 @@ if [[ -e "/.whaley/config/kind.yml" ]]; then
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config
 elif [[ -e "/.whaley/config/kind.yaml" ]]; then
-    _config=/.whaley/config/kind.yml
+    _config=/.whaley/config/kind.yaml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config
 fi

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -34,9 +34,9 @@ NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
-# Check if kind.yml has been mounted in /.whaley/user-config
-if [[ -e "/.whaley/user-config/kind.yml "]]; then
-    _config=/.whaley/user-config/kind.yml
+# Check if kind.yml has been mounted in /.whaley/config/kind.yml
+if [[ -e "/.whaley/config/kind.yml "]]; then
+    _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config
 fi

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -45,7 +45,7 @@ fi
 echo -e ${GREEN}
 echo "> Building the cluster"
 echo -e ${NOCOLOR}
-bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config ${_config}' || exit 1
+/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config ${_config} || exit 1
 
 # Retrieve docker container id
 # Docker >= 1.12 - $HOSTNAME seems to be the short container id

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -38,10 +38,12 @@ export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME
 if [[ -e "/.whaley/config/kind.yml" ]]; then
     _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    echo
     cat $_config
 elif [[ -e "/.whaley/config/kind.yaml" ]]; then
     _config=/.whaley/config/kind.yaml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    echo
     cat $_config
 fi
     

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -34,8 +34,12 @@ NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
-# Check if kind.yml has been mounted in /.whaley/config/kind.yml
+# Check if kind.yml (or .yaml) has been mounted in /.whaley/config/kind.yml (or .yaml)
 if [[ -e "/.whaley/config/kind.yml" ]]; then
+    _config=/.whaley/config/kind.yml
+    echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    cat $_config
+elif [[ -e "/.whaley/config/kind.yaml" ]]; then
     _config=/.whaley/config/kind.yml
     echo "INFO :: User cluster config file detected! The following configuration will be used:"
     cat $_config

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -3,7 +3,7 @@
 MASTERS=1
 WORKERS=2
 NAME=whaley
-_config=/.whaley/kind.yaml
+_config=/.whaley/kind.yml
 
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in

--- a/scripts/cluster-init.sh
+++ b/scripts/cluster-init.sh
@@ -3,6 +3,8 @@
 MASTERS=1
 WORKERS=2
 NAME=whaley
+_config=/.whaley/kind.yaml
+
 # Parse options from the CLI
 while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     -w | --workers )
@@ -14,17 +16,17 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
     --name)
         if [[ -n "$2" && ! "$2" =~ ^- && ! "$1" == "--" ]]; then
             shift; NAME=$1
-            sed -i "s/whaley/$NAME/g" /.whaley/kind.yml
+            sed -i "s/whaley/$NAME/g" $_config
         fi
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
 # Populate kind config file with both control-plane and workers nodes
 for (( i = 0 ; i < $MASTERS; i++)); do
-    echo "- role: control-plane" >> /.whaley/kind.yml
+    echo "- role: control-plane" >> $_config
 done
 for (( i = 0 ; i < $WORKERS; i++)); do
-    echo "- role: worker" >> /.whaley/kind.yml
+    echo "- role: worker" >> $_config
 done
 
 GREEN='\033[0;32m'
@@ -32,10 +34,18 @@ NOCOLOR='\033[0m'
 # TO-DO: Should I replace whaley with the container name?
 export PS1="\[\e]0;\u@${NAME}: \w\a\]${debian_chroot:+($debian_chroot)}\u@${NAME}:\w\$ "
 
+# Check if kind.yml has been mounted in /.whaley/user-config
+if [[ -e "/.whaley/user-config/kind.yml "]]; then
+    _config=/.whaley/user-config/kind.yml
+    echo "INFO :: User cluster config file detected! The following configuration will be used:"
+    cat $_config
+fi
+    
+
 echo -e ${GREEN}
 echo "> Building the cluster"
 echo -e ${NOCOLOR}
-bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config /.whaley/kind.yml' || exit 1
+bash -c '/usr/local/bin/kind create cluster --image kindest/node:v1.25.2 --config ${_config}' || exit 1
 
 # Retrieve docker container id
 # Docker >= 1.12 - $HOSTNAME seems to be the short container id


### PR DESCRIPTION
### Added

- Detect custom cluster configuration file (they must be named `kind.yaml` or `kind.yml`) in `/.whaley/config` to customize `kind` cluster creation using an already made configuration file:

```shell
whaley@docker:~$ docker run --name k8s-local-dev --rm \
-p 30303:8001 \
-v /var/run/docker.sock:/var/run/docker.sock \
-v /home/imgios/kind.yml:/.whaley/config/kind.yml \
-it whaley:dev
```

- OpenContainers labels about the author, the source code and the image description.